### PR TITLE
Force square plot for graph sketcher, update P5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-loader": "^8.2.2",
     "file-loader": "^6.2.0",
     "lodash": "^4.17.21",
-    "p5": "^1.4.0",
+    "p5": "^1.5.0",
     "ts-loader": "^9.2.6",
     "typescript": "^4.4.3",
     "webpack": "^5.57.1",
@@ -45,7 +45,7 @@
     "webpack-merge": "^5.8.0"
   },
   "peerDependencies": {
-    "p5": "^1.4.0"
+    "p5": "^1.5.0"
   },
   "browserslist": [
     "> 5%",

--- a/src/GraphView.ts
+++ b/src/GraphView.ts
@@ -268,7 +268,7 @@ export default class GraphView {
         this.p.fill(0);
 
         this.p.text("O", this.canvasProperties.centerPx[0] - 15, this.canvasProperties.centerPx[1] + 15);
-        this.p.text("x", this.canvasProperties.centerPx[0] + this.canvasProperties.axisLengthPx/2 - 2 * this.PADDING, this.canvasProperties.centerPx[1] + 15);
+        this.p.text("x", this.canvasProperties.centerPx[0] + this.canvasProperties.axisLengthPx/2 - this.PADDING, this.canvasProperties.centerPx[1] + 15);
         this.p.text("y", this.canvasProperties.centerPx[0] + 5, this.canvasProperties.centerPx[1] - this.canvasProperties.axisLengthPx / 2 + this.PADDING);
 
         this.p.pop();


### PR DESCRIPTION
This PR forces the plot to remain square regardless of display resolution, with the aim of making marking more consistent across graphs sketched on different displays.