### PR TITLE
Use the same pattern as `inequality` to generate module/type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-dist
+lib
 .idea/
 .vscode/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -3,15 +3,11 @@
 A graph sketching application for [Isaac Physics](https://isaacphysics.org).
 
 ## Development
-This graph sketcher is a dependency and cannot be run standalone. To test it locally, you can temporarily modify the 
-client's `package.json` like so (assuming it exists in the same directory):
-```javascript
-"dependencies": {
-    ...
-    "isaac-graph-sketcher": "file:../isaac-graph-sketcher",
-    ...
-}
-```
+This graph sketcher is a dependency and cannot be run standalone.
+
+To test it locally, you will need to run `yarn link` in this project, and then `yarn link "isaac-graph-sketcher"` in the 
+project you want to test it in.
+
 You will need to run `yarn run build` on this project to update the dependency when changes are made. This should hot-reload
 the client if set up as described.
 

--- a/package.json
+++ b/package.json
@@ -2,12 +2,11 @@
   "name": "isaac-graph-sketcher",
   "version": "0.9.6",
   "description": "A graph sketching application to serve Isaac Physics.",
-  "main": "./dist/bundle.js",
+  "main": "./lib/bundle.js",
   "files": [
-    "dist",
-    "src"
+    "lib"
   ],
-  "types": "./src/types.d.ts",
+  "types": "./lib/src/GraphSketcher.d.ts",
   "scripts": {
     "dev": "webpack --config webpack.dev.js --watch --mode development",
     "build": "tsc --build && webpack --config webpack.config.js --mode production",

--- a/src/GraphSketcher.ts
+++ b/src/GraphSketcher.ts
@@ -60,7 +60,7 @@ export class GraphSketcher {
     public  checkPointsRedo: any[] = [];
 
     private CURVE_LIMIT = 3;
-    private MOUSE_DETECT_RADIUS = 10;
+    private MOUSE_DETECT_RADIUS = 20;
 
     // action recorder
     private action: Action = Action.NO_ACTION;

--- a/src/GraphSketcher.ts
+++ b/src/GraphSketcher.ts
@@ -60,7 +60,7 @@ export class GraphSketcher {
     public  checkPointsRedo: any[] = [];
 
     private CURVE_LIMIT = 3;
-    private MOUSE_DETECT_RADIUS = 20;
+    private MOUSE_DETECT_RADIUS = 10;
 
     // action recorder
     private action: Action = Action.NO_ACTION;

--- a/src/GraphUtils.ts
+++ b/src/GraphUtils.ts
@@ -161,6 +161,7 @@ export function linearLineStyle(pts: Point[]) {
 export function bezierLineStyle(pts: Point[]) {
 
     // See https://github.com/josdejong/mathjs/blob/v5.8.0/src/function/probability/product.js
+    // Product of all integers between i and n
     let product = function(i: number, n: number): number {
         let half;
         if (n < i) {
@@ -173,24 +174,22 @@ export function bezierLineStyle(pts: Point[]) {
         return product(i, half) * product(half + 1, n);
     }
 
-        // See https://github.com/josdejong/mathjs/blob/v5.8.0/src/function/probability/combinations.js
+    // See https://github.com/josdejong/mathjs/blob/v5.8.0/src/function/probability/combinations.js
+    // Compute the number of ways of picking k unordered outcomes from n possibilities
     let combinations = function(n: number, k: number): number {
         let prodrange, nMinusk;
-
-            if (n < 0 || k < 0) {
+        if (n < 0 || k < 0) {
             throw new TypeError('Positive integer value expected in function combinations');
         }
         if (k > n) {
             throw new TypeError('k must be less than or equal to n');
         }
-
-            nMinusk = n - k;
-
-            if (k < nMinusk) {
+        nMinusk = n - k;
+        if (k < nMinusk) {
             prodrange = product(nMinusk + 1, n);
             return prodrange / product(1, k);
         }
-        prodrange = product(k + 1, n)
+        prodrange = product(k + 1, n);
         return prodrange / product(1, nMinusk);
     }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,10 @@
 import p5 from 'p5';
 import { Point, Curve } from './GraphSketcher';
 
+// FIXME this file is completely pointless at the moment, but we should use it to
+//  declare types so the final library can just consist of a single bundled .js file
+//  and a .d.ts file
+
 declare module "GraphView" {
     export class GraphView {
         constructor(p: p5, width: number, height: number);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -11,7 +11,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    "outDir": "./lib",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "composite": true,                     /* Enable project compilation */
     "incremental": true,                   /* Enable incremental compilation */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = (_env, argv) => { return {
-  entry: './dist/src/GraphSketcher.js',
+  entry: './src/GraphSketcher.ts',
   devtool: false,
   optimization: {
     usedExports: true,
@@ -59,7 +59,7 @@ module.exports = (_env, argv) => { return {
   },
   output: {
     filename: 'bundle.js',
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(__dirname, 'lib'),
     library: {
       name: 'isaac-graph-sketcher',
       type: 'umd',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,10 +1964,10 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-p5@^1.4.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/p5/-/p5-1.4.2.tgz#c258fcf655ff75bd4e8b530607c9a96e6a556023"
-  integrity sha512-J5zqZ/l1NIbJSuNr/FH9nDYgBRg7/NubStNPnx1fQCMSAgxI6peKDHs9i5iaG9EuwbJzjuG6/5bX/D0lqqrP9A==
+p5@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/p5/-/p5-1.6.0.tgz#eaf4e69e377d6a5e91041ca485743b0fc53d9dfb"
+  integrity sha512-RowF+RxfVUhJm/YKXL5TCFzTqnwAIwK6W1VGs9LAqSf3PCmLz9Igbxzlf0Ry5IMV71L42wipCdH/bDiNsqAstA==
 
 path-exists@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
We were having to import this library in `isaac-react-app` using `import ... from "isaac-graph-sketcher/dist/src/GraphSketcher"` which is awful and just means that the module and types definitions are set up badly. 

This PR essentially copies how `inequality` manages this problem. The changes mean that we can both use `yarn link` to develop/test this library locally, and use `import ... from "isaac-graph-sketcher"` in `isaac-react-app`.

I've tested it with `yarn link` locally and it seems to work absolutely fine.