### PR TITLE
Stop curves from getting lost

### DIFF
--- a/src/GraphSketcher.ts
+++ b/src/GraphSketcher.ts
@@ -61,7 +61,7 @@ export class GraphSketcher {
 
     private CURVE_LIMIT = 3;
     private MOUSE_DETECT_RADIUS = 10;
-    private REQUIRED_CURVE_ON_SCREEN_RATIO = 0.15; // 15% of a curves points must be on screen or it will be deleted
+    private REQUIRED_CURVE_ON_SCREEN_RATIO = 0.30; // 30% of a curves points must be on screen or it will be deleted
 
     // action recorder
     private action: Action = Action.NO_ACTION;

--- a/src/GraphView.ts
+++ b/src/GraphView.ts
@@ -64,6 +64,12 @@ export default class GraphView {
     }
 
     drawKnot(knot: Point, color?: number[]) {
+        // Don't draw knots that are outside the plot area
+        if (knot[0] < this.canvasProperties.plotStartPx[0] || knot[0] > this.canvasProperties.plotEndPx[0] ||
+            knot[1] < this.canvasProperties.plotStartPx[1] || knot[1] > this.canvasProperties.plotEndPx[1]
+        ) {
+            return;
+        }
         if (!color) {
             color = this.DEFAULT_KNOT_COLOR;
         }
@@ -284,6 +290,27 @@ export default class GraphView {
         this.drawHorizontalAxis(this.CURVE_STRKWEIGHT);
         this.drawVerticalAxis(this.CURVE_STRKWEIGHT);
         this.drawLabel();
+    }
+
+    drawBoundaries(canvasProperties: CanvasProperties) {
+        this.p.push();
+        this.p.noStroke();
+        this.p.fill(255, 180);
+        this.p.rect(0, 0, canvasProperties.plotStartPx[0], canvasProperties.heightPx);
+        this.p.rect(canvasProperties.plotEndPx[0], 0, canvasProperties.plotStartPx[0], canvasProperties.heightPx);
+        this.p.pop();
+    }
+
+    drawOutOfBoundsWarning(point: Point, canvasProperties: CanvasProperties) {
+        const x = this.p.constrain(point[0], canvasProperties.plotStartPx[0] + 20, canvasProperties.plotEndPx[0] - 20);
+        const y = this.p.constrain(point[1], canvasProperties.plotStartPx[1] + 20, canvasProperties.plotEndPx[1] - 20);
+        // Draw a red cross centered at (x, y) to indicate that a curve will be deleted if it is moved there
+        this.p.push();
+        this.p.stroke(255, 0, 0);
+        this.p.strokeWeight(2);
+        this.p.line(x - 10, y - 10, x + 10, y + 10);
+        this.p.line(x - 10, y + 10, x + 10, y - 10);
+        this.p.pop();
     }
 
     drawCorner(stretchMode: string, c: Curve) {


### PR DESCRIPTION
This fixes a couple of things:
 
- Allows you to interact with curves that are dragged away from the grid.
- Solves the "losing curves off screen" issue by just deleting a curve if half of it is off-grid at the end of a move. This check happens after a curve stretch, a "point" stretch (whatever that is) and a move. A red cross appears near the activity if this deletion is about to happen.
- Keep drawing inside the grid by constraining mouse co-ords within the grid boundaries. This seems nicer than just cancelling a draw action if the mouse wanders off-grid 