### PR TITLE
Reset button

### DIFF
--- a/src/GraphSketcher.ts
+++ b/src/GraphSketcher.ts
@@ -112,6 +112,7 @@ export class GraphSketcher {
     private elements: HTMLElement[] = [];
     private colorSelect?: HTMLSelectElement;
     private trashButton?: HTMLButtonElement;
+    private resetButton?: HTMLButtonElement;
 
     // The following public members can be modified from the outside
     public drawingColorName: string = "Blue";
@@ -155,6 +156,9 @@ export class GraphSketcher {
             this.trashButton = document.getElementById("graph-sketcher-ui-trash-button") as HTMLButtonElement;
             this.trashButton.addEventListener('click', this.deleteSelectedCurve);
             this.elements.push(this.trashButton);
+            this.resetButton = document.getElementById("graph-sketcher-ui-reset-button") as HTMLButtonElement;
+            this.resetButton.addEventListener('click', this.deleteAllCurves);
+            this.elements.push(this.resetButton);
 
             this.elements.push(document.getElementById("graph-sketcher-ui-submit-button") as HTMLElement);
             this.elements.push(document.getElementById("graph-sketcher-ui-help-button") as HTMLElement);
@@ -202,6 +206,15 @@ export class GraphSketcher {
     private deleteSelectedCurve = () => {
         if (isDefined(this.clickedCurveIdx) && isDefined(this._state.curves)) {
             this._state.curves.splice(this.clickedCurveIdx, 1);
+            this.clickedCurveIdx = undefined;
+            this.reDraw();
+        }
+    }
+
+    private deleteAllCurves = () => {
+        if (isDefined(this._state.curves)) {
+            this._state.curves = [];
+            this.movedCurveIdx = undefined;
             this.clickedCurveIdx = undefined;
             this.reDraw();
         }
@@ -887,6 +900,9 @@ export class GraphSketcher {
     private updateExternalUI = () => {
         if (isDefined(this.trashButton)) {
             this.trashButton.disabled = !isDefined(this.clickedCurveIdx);
+        }
+        if (isDefined(this.resetButton)) {
+            this.resetButton.disabled = this._state.curves === undefined || this._state.curves.length === 0;
         }
     }
 

--- a/src/GraphSketcher.ts
+++ b/src/GraphSketcher.ts
@@ -205,6 +205,12 @@ export class GraphSketcher {
 
     private deleteSelectedCurve = () => {
         if (isDefined(this.clickedCurveIdx) && isDefined(this._state.curves)) {
+            // Checkpoint
+            this.checkPoint = {};
+            this.checkPoint.curvesJSON = JSON.stringify(this._state);
+            this.checkPoint.clickedCurveIdx = this.clickedCurveIdx;
+            this.checkPointsUndo.push(this.checkPoint);
+            // Delete curve
             this._state.curves.splice(this.clickedCurveIdx, 1);
             this.clickedCurveIdx = undefined;
             this.reDraw();
@@ -213,6 +219,12 @@ export class GraphSketcher {
 
     private deleteAllCurves = () => {
         if (isDefined(this._state.curves)) {
+            // Checkpoint
+            this.checkPoint = {};
+            this.checkPoint.curvesJSON = JSON.stringify(this._state);
+            this.checkPoint.clickedCurveIdx = this.clickedCurveIdx;
+            this.checkPointsUndo.push(this.checkPoint);
+            // Delete curves
             this._state.curves = [];
             this.movedCurveIdx = undefined;
             this.clickedCurveIdx = undefined;

--- a/src/GraphSketcher.ts
+++ b/src/GraphSketcher.ts
@@ -111,8 +111,7 @@ export class GraphSketcher {
     public canvas?: p5.Renderer;
     private elements: HTMLElement[] = [];
     private colorSelect?: HTMLSelectElement;
-    private trashButton?: HTMLElement;
-    public isTrashActive? = false;
+    private trashButton?: HTMLButtonElement;
 
     // The following public members can be modified from the outside
     public drawingColorName: string = "Blue";
@@ -153,7 +152,7 @@ export class GraphSketcher {
             this.elements.push(document.getElementById("graph-sketcher-ui-bezier-button") as HTMLElement);
             this.elements.push(document.getElementById("graph-sketcher-ui-linear-button") as HTMLElement);
 
-            this.trashButton = document.getElementById("graph-sketcher-ui-trash-button") as HTMLElement;
+            this.trashButton = document.getElementById("graph-sketcher-ui-trash-button") as HTMLButtonElement;
             this.trashButton.addEventListener('click', this.deleteSelectedCurve);
             this.elements.push(this.trashButton);
 
@@ -204,18 +203,18 @@ export class GraphSketcher {
         if (isDefined(this.clickedCurveIdx) && isDefined(this._state.curves)) {
             this._state.curves.splice(this.clickedCurveIdx, 1);
             this.clickedCurveIdx = undefined;
+            this.reDraw();
         }
     }
 
     private isPointOverButton = (pt: Point, button: HTMLElement) => {
         const rect = button.getBoundingClientRect();
-
         if (rect) {
             let left = rect.left;
             let top = rect.top;
             let width = rect.width;
             let height = rect.height;
-            return (pt[0] > left && pt[0] < left + width && pt[1] > top && pt[1] < top + height);
+            return pt[0] > left && pt[0] < left + width && pt[1] > top && pt[1] < top + height;
         }
         return false;
     }
@@ -566,8 +565,6 @@ export class GraphSketcher {
         } else if (this.action === Action.MOVE_CURVE && isDefined(this.movedCurveIdx) && isDefined(this._state.curves)) {
             this.p.cursor(this.p.MOVE);
 
-            this.isTrashActive = this.isPointOverButton(mousePosition, this.trashButton as HTMLElement);
-
             let dx = mousePosition[0] - this.prevMousePt[0];
             let dy = mousePosition[1] - this.prevMousePt[1];
             this.prevMousePt = mousePosition;
@@ -755,12 +752,10 @@ export class GraphSketcher {
             this.checkPointsRedo = [];
 
             // Delete the curve if it is in the trash, or if it is mostly off screen
-            if (isDefined(this.movedCurveIdx) && isDefined(this._state.curves) && (this.isTrashActive || isDefined(this.outOfBoundsCurvePoint))) {
+            if (isDefined(this.movedCurveIdx) && isDefined(this._state.curves) && isDefined(this.outOfBoundsCurvePoint)) {
                 this._state.curves.splice(this.movedCurveIdx, 1);
                 this.clickedCurveIdx = undefined;
             }
-
-            this.isTrashActive = false;
             this.outOfBoundsCurvePoint = undefined;
             this.reDraw();
 
@@ -889,8 +884,15 @@ export class GraphSketcher {
         }
     }
 
+    private updateExternalUI = () => {
+        if (isDefined(this.trashButton)) {
+            this.trashButton.disabled = !isDefined(this.clickedCurveIdx);
+        }
+    }
+
     // equivalent to 'locally' refreshing the canvas
     public reDraw = () => {
+        this.updateExternalUI();
         // FIXME Save the background grid and axes in a graphics object inside GraphView so they don't
         //  have to be redrawn every time - would need to be redrawn if the canvas size changes
         this.graphView.drawBackground(this.canvasProperties);


### PR DESCRIPTION
Add "reset" functionality, which removes all curves on screen. 

This also more tightly couples the trash and reset buttons to this library, so we have better control over visual cues based on the state of the graph sketcher.

Needs to be released alongside https://github.com/isaacphysics/isaac-react-app/pull/727
