### PR TITLE
Allow stretching tiny graphs, prevent graph flips

### DIFF
--- a/src/GraphSketcher.ts
+++ b/src/GraphSketcher.ts
@@ -625,56 +625,44 @@ export class GraphSketcher {
             // update the position of stretched vertex
             switch (this.stretchMode) {
                 case "bottomLeft":
-                    if (orx < 30 && dx > 0  || ory < 30 && dy > 0) {
-                        return;
-                    }
-                    currentCurve.minX += dx;
-                    currentCurve.minY += dy;
+                    currentCurve.minX += (orx < 30 && dx > 0) ? 0 : dx + Math.min(0, currentCurve.maxX - (currentCurve.minX + dx) - 30);
+                    currentCurve.minY += (ory < 30 && dy > 0) ? 0 : dy + Math.min(0, currentCurve.maxY - (currentCurve.minY + dy) - 30);
                     break;
                 case "bottomRight":
-                    if (orx < 30 && dx < 0 || ory < 30 && dy > 0) {
-                        return;
-                    }
-                    currentCurve.maxX += dx;
-                    currentCurve.minY += dy;
+                    currentCurve.maxX += (orx < 30 && dx < 0) ? 0 : dx - Math.min(0, (currentCurve.maxX + dx) - currentCurve.minX - 30);
+                    currentCurve.minY += (ory < 30 && dy > 0) ? 0 : dy + Math.min(0, currentCurve.maxY - (currentCurve.minY + dy) - 30);
                     break;
                 case "topRight":
-                    if (orx < 30 && dx < 0 || ory < 30 && dy < 0) {
-                        return;
-                    }
-                    currentCurve.maxX += dx;
-                    currentCurve.maxY += dy;
+                    currentCurve.maxX += (orx < 30 && dx < 0) ? 0 : dx - Math.min(0, (currentCurve.maxX + dx) - currentCurve.minX - 30);
+                    currentCurve.maxY += (ory < 30 && dy < 0) ? 0 : dy - Math.min(0, (currentCurve.maxY + dy) - currentCurve.minY - 30);
                     break;
                 case "topLeft":
-                    if (orx < 30 && dy > 0 || ory < 30 && dy < 0) {
-                        return;
-                    }
-                    currentCurve.minX += dx;
-                    currentCurve.maxY += dy;
+                    currentCurve.minX += (orx < 30 && dx > 0) ? 0 : dx + Math.min(0, currentCurve.maxX - (currentCurve.minX + dx) - 30);
+                    currentCurve.maxY += (ory < 30 && dy < 0) ? 0 : dy - Math.min(0, (currentCurve.maxY + dy) - currentCurve.minY - 30);
                     break;
                 case "bottomMiddle":
                     if ( ory < 30 && dy > 0) {
                         return;
                     }
-                    currentCurve.minY += dy;
+                    currentCurve.minY += dy + Math.min(0, currentCurve.maxY - (currentCurve.minY + dy) - 30);
                     break;
                 case "topMiddle":
                     if (ory < 30 && dy < 0) {
                         return;
                     }
-                    currentCurve.maxY += dy;
+                    currentCurve.maxY += dy - Math.min(0, (currentCurve.maxY + dy) - currentCurve.minY - 30);
                     break;
                 case "leftMiddle":
                     if (orx < 30 && dx > 0) {
                         return;
                     }
-                    currentCurve.minX += dx;
+                    currentCurve.minX += dx + Math.min(0, currentCurve.maxX - (currentCurve.minX + dx) - 30);
                     break;
                 case "rightMiddle":
                     if (orx < 30 && dx < 0) {
                         return;
                     }
-                    currentCurve.maxX += dx;
+                    currentCurve.maxX += dx - Math.min(0, (currentCurve.maxX + dx) - currentCurve.minX - 30);
                     break;
             }
 
@@ -749,7 +737,7 @@ export class GraphSketcher {
                 this.p.push();
                 this.p.stroke(this.graphView.CURVE_COLORS[this.drawnColorIdx]);
                 this.p.strokeWeight(this.graphView.CURVE_STRKWEIGHT);
-                if (this.drawnPts.length > 0) {
+                    if (this.drawnPts.length > 0) {
                     let precedingPoint = this.drawnPts[this.drawnPts.length - 1];
                     this.p.line(precedingPoint[0], precedingPoint[1], constrainedMouseX, constrainedMouseY);
                 }


### PR DESCRIPTION
Stretching previously stopped entirely if the width along any axis became too small, it now allows stretching along the other axis. Also fixes a related bug whereby stretching too much flipped the entire graph, despite the cap.