### PR TITLE
Allow custom axis labels, with x/y default

### DIFF
--- a/src/GraphSketcher.ts
+++ b/src/GraphSketcher.ts
@@ -81,6 +81,14 @@ interface Checkpoint {
     clickedCurveIdx?: number;
 }
 
+interface GraphSketcherOptions {
+    previewMode: boolean;
+    initialCurves?: Curve[];
+    allowMultiValuedFunctions?: boolean;
+    axisLabelX?: string;
+    axisLabelY?: string;
+}
+
 export class GraphSketcher {
     private p: p5;
     private canvasProperties: CanvasProperties;
@@ -115,7 +123,6 @@ export class GraphSketcher {
     // for moving and stretching curve
     private movedCurveIdx?: number;
     private stretchMode?: StretchMode;
-    private isMaxima?: boolean;
     private outOfBoundsCurvePoint?: Point;
     private rotationCenter?: Point;
 
@@ -150,6 +157,9 @@ export class GraphSketcher {
     private trashButton?: HTMLButtonElement;
     private resetButton?: HTMLButtonElement;
 
+    private axisLabelX?: string;
+    private axisLabelY?: string;
+
     // The following public members can be modified from the outside
     public drawingColorName: string = "Blue";
     public selectedLineType = LineType.BEZIER;
@@ -157,7 +167,7 @@ export class GraphSketcher {
 
     public setupDone = false;
 
-    constructor(p: p5, width: number, height: number, options: { previewMode: boolean, initialCurves?: Curve[], allowMultiValuedFunctions?: boolean}) {
+    constructor(p: p5, width: number, height: number, options: GraphSketcherOptions) {
         this.p = p;
 
         // todo: we could use the state pattern for these methods, as behaviour largely depends on the current Action
@@ -174,8 +184,11 @@ export class GraphSketcher {
 
         this.p.setup = this.setup;
 
+        this.axisLabelX = options.axisLabelX;
+        this.axisLabelY = options.axisLabelY;
+
         this.canvasProperties = GraphSketcher.getCanvasPropertiesForResolution(width, height);
-        this.graphView = new GraphView(p, this.canvasProperties);
+        this.graphView = new GraphView(p, this.canvasProperties, this.axisLabelX, this.axisLabelY);
         this.previewMode = options.previewMode;
         this.allowMultiValuedFunctions = options.allowMultiValuedFunctions ?? false;
         this._state = GraphUtils.decodeData({ curves: options.initialCurves ?? [], canvasWidth: width, canvasHeight: height }, this.canvasProperties);
@@ -986,7 +999,7 @@ export class GraphSketcher {
     };
 }
 
-export function makeGraphSketcher(element: HTMLElement | undefined | null, width: number, height: number, options: { previewMode: boolean, initialCurves?: Curve[], allowMultiValuedFunctions?: boolean } = { previewMode: false, allowMultiValuedFunctions: false }): { sketch?: GraphSketcher, p: p5 } {
+export function makeGraphSketcher(element: HTMLElement | undefined | null, width: number, height: number, options: GraphSketcherOptions = { previewMode: false, allowMultiValuedFunctions: false }): { sketch?: GraphSketcher, p: p5 } {
     let sketch: GraphSketcher | undefined;
     const p = new p5(instance => {
         sketch = new GraphSketcher(instance, width, height, options);

--- a/src/GraphView.ts
+++ b/src/GraphView.ts
@@ -46,6 +46,9 @@ export default class GraphView {
     private ORIGIN_SLOP: number;
     private slopVisible = false;
 
+    private axisLabelX?: string;
+    private axisLabelY?: string;
+
     private DOT_LINE_COLOR = [123];
     private DEFAULT_KNOT_COLOR = [77,77,77];
 
@@ -57,13 +60,16 @@ export default class GraphView {
     public CURVE_STRKWEIGHT = 2;
     public KNOT_DETECT_COLOR = [0];
 
-    constructor(p: p5, canvasProperties: CanvasProperties) {
+    constructor(p: p5, canvasProperties: CanvasProperties, axisLabelX?: string, axisLabelY?: string) {
         this.p = p;
-        this.PADDING = 0.025 * canvasProperties.axisLengthPx;
+        this.PADDING = 0.03 * canvasProperties.axisLengthPx;
 
         // these values should be synced with those in IsaacGraphSketcherSettings.java in the API
         this.AXIS_SLOP = 0.005 * canvasProperties.axisLengthPx;
         this.ORIGIN_SLOP = 0.01 * canvasProperties.axisLengthPx;
+
+        this.axisLabelX = axisLabelX;
+        this.axisLabelY = axisLabelY;
 
         this.canvasProperties = canvasProperties;
         this.backgroundGraphic = this.p.createGraphics(canvasProperties.widthPx, canvasProperties.heightPx);
@@ -355,8 +361,25 @@ export default class GraphView {
         this.backgroundGraphic.fill(0);
 
         this.backgroundGraphic.text("O", this.canvasProperties.centerPx.x - 15, this.canvasProperties.centerPx.y + 15);
-        this.backgroundGraphic.text("x", this.canvasProperties.centerPx.x + this.canvasProperties.axisLengthPx/2 - this.PADDING, this.canvasProperties.centerPx.y + 15);
-        this.backgroundGraphic.text("y", this.canvasProperties.centerPx.x + 5, this.canvasProperties.centerPx.y - this.canvasProperties.axisLengthPx / 2 + this.PADDING);
+
+        // TODO: render these axis labels in LaTeX
+
+        // // make an HTML element
+        // const xAxisLabelLatex = this.p.createP();
+        // // render the LaTeX into it
+        // katex.render(GraphSketcher.axisLabelX, xAxisLabelLatex.elt);
+        // // convert into an image
+        // const _xAxisLabelPromise = domtoimage.toSvg(xAxisLabelLatex.elt).then((dataUrl) => {
+        //     // create an image element from this
+        //     const xAxisLabelImage = this.p.createImg(dataUrl, "");
+        //     // render the image
+        //     this.backgroundGraphic.image(xAxisLabelImage, this.canvasProperties.centerPx.x + this.canvasProperties.axisLengthPx/2 - this.PADDING, this.canvasProperties.centerPx.y + 15, 40, 40);
+        // });
+        // // then remove the original element
+        // xAxisLabelLatex.remove();
+        
+        this.backgroundGraphic.text(this.axisLabelX ?? "x", this.canvasProperties.centerPx.x + this.canvasProperties.axisLengthPx/2 - this.PADDING, this.canvasProperties.centerPx.y + 15);
+        this.backgroundGraphic.text(this.axisLabelY ?? "y", this.canvasProperties.centerPx.x + 5, this.canvasProperties.centerPx.y - this.canvasProperties.axisLengthPx / 2 + this.PADDING);
 
         this.backgroundGraphic.pop();
     }


### PR DESCRIPTION
Allows the passing through of custom axis labels from the frontend. These are currently rendered in plaintext, we should consider moving to latex if we can fix rendering images on the canvas.